### PR TITLE
refactor(tests): migrate doctests to markdown tests in stub files

### DIFF
--- a/pyochain/collections/_deque.pyi
+++ b/pyochain/collections/_deque.pyi
@@ -71,17 +71,16 @@ class Deque[T](PyoMutableSequence[T]):
 
         Example:
             ```python
-            >>> from pyochain.collections import Deque
-            >>> from collections import deque
-            >>>
-            >>> original = deque([1, 2, 3])
-            >>> deque_obj = Deque.from_ref(original)
-            >>> deque_obj
-            Deque([1, 2, 3])
-            >>> original.append(4)
-            >>> deque_obj
-            Deque([1, 2, 3, 4])
+            from pyochain.collections import Deque
+            from collections import deque
 
+            original = deque([1, 2, 3])
+            deque_obj = Deque.from_ref(original)
+
+            assert deque_obj == Deque([1, 2, 3])
+            original.append(4)
+
+            assert deque_obj == Deque([1, 2, 3, 4])
             ```
         """
 
@@ -166,12 +165,12 @@ class Deque[T](PyoMutableSequence[T]):
 
         Examples:
             ```python
-            >>> from pyochain.collections import Deque
-            >>> d = Deque([1, 2, 3])
-            >>> d.append_left(0)
-            >>> d
-            Deque([0, 1, 2, 3])
+            from pyochain.collections import Deque
 
+            d = Deque([1, 2, 3])
+            d.append_left(0)
+
+            assert d == Deque([0, 1, 2, 3])
             ```
         """
 
@@ -187,17 +186,15 @@ class Deque[T](PyoMutableSequence[T]):
 
         Example:
             ```python
-            >>> from pyochain.collections import Deque
-            >>> d = Deque([1, 2, 3])
-            >>> d_copy = d.copy()
-            >>> d_copy
-            Deque([1, 2, 3])
-            >>> d.append(4)
-            >>> d
-            Deque([1, 2, 3, 4])
-            >>> d_copy
-            Deque([1, 2, 3])
+            from pyochain.collections import Deque
 
+            d = Deque([1, 2, 3])
+            d_copy = d.copy()
+
+            assert d_copy == Deque([1, 2, 3])
+            d.append(4)
+            assert d == Deque([1, 2, 3, 4])
+            assert d_copy == Deque([1, 2, 3])
             ```
         """
 
@@ -209,12 +206,12 @@ class Deque[T](PyoMutableSequence[T]):
 
         Examples:
             ```python
-            >>> from pyochain.collections import Deque
-            >>> d = Deque([1, 2, 3])
-            >>> d.extend_left([0, -1])
-            >>> d
-            Deque([-1, 0, 1, 2, 3])
+            from pyochain.collections import Deque
 
+            d = Deque([1, 2, 3])
+            d.extend_left([0, -1])
+
+            assert d == Deque([-1, 0, 1, 2, 3])
             ```
         """
 
@@ -226,13 +223,12 @@ class Deque[T](PyoMutableSequence[T]):
 
         Examples:
             ```python
-            >>> from pyochain.collections import Deque
-            >>> d = Deque([1, 2, 3])
-            >>> d.pop_left()
-            1
-            >>> d
-            Deque([2, 3])
+            from pyochain.collections import Deque
 
+            d = Deque([1, 2, 3])
+
+            assert d.pop_left() == 1
+            assert d == Deque([2, 3])
             ```
         """
     def rotate(self, n: int = 1, /) -> Self:
@@ -246,13 +242,12 @@ class Deque[T](PyoMutableSequence[T]):
 
         Examples:
             ```python
-            >>> from pyochain.collections import Deque
-            >>> d = Deque([1, 2, 3, 4, 5])
-            >>> d.rotate(2)
-            Deque([4, 5, 1, 2, 3])
-            >>> d.rotate(-3)
-            Deque([2, 3, 4, 5, 1])
+            from pyochain.collections import Deque
 
+            d = Deque([1, 2, 3, 4, 5])
+
+            assert d.rotate(2) == Deque([4, 5, 1, 2, 3])
+            assert d.rotate(-3) == Deque([2, 3, 4, 5, 1])
             ```
         """
 

--- a/pyochain/core/_iterators.pyi
+++ b/pyochain/core/_iterators.pyi
@@ -25,45 +25,42 @@ class Iter[T](PyoIterator[T]):
 
     Example:
         ```python
-        >>> from pyochain import Iter, Seq
-        >>>
-        >>> data = (0, 1, 2, 3, 4)
-        >>> Iter(data).collect(Seq)
-        Seq(0, 1, 2, 3, 4)
-        >>> iterator = Iter(data)
-        >>> # First we have a tuple iterator
-        >>> iterator.__iter__().__class__.__name__
-        'tuple_iterator'
-        >>> # Now we have a map object
-        >>> mapped = iterator.map(lambda x: x * 2)
-        >>> mapped.__iter__().__class__.__name__
-        'map'
-        >>> # We collect it, by default into a Seq
-        >>> mapped.collect(Seq)
-        Seq(0, 2, 4, 6, 8)
-        >>> # iterator is now exhausted
-        >>> iterator.collect(Seq)
-        Seq()
+        from pyochain import Iter, Seq
 
+        data = (0, 1, 2, 3, 4)
+
+        assert Iter(data).collect(Seq) == Seq([0, 1, 2, 3, 4])
+        iterator = Iter(data)
+
+        # First we have a tuple iterator
+        assert iterator.__iter__().__class__.__name__ == "tuple_iterator"
+
+        # Now we have a map object
+        mapped = iterator.map(lambda x: x * 2)
+        assert mapped.__iter__().__class__.__name__ == "map"
+
+        # We collect it, by default into a Seq
+        assert mapped.collect(Seq) == Seq([0, 2, 4, 6, 8])
+
+        # iterator is now exhausted
+        assert iterator.collect(Seq) == Seq([])
         ```
         You can also easily create an `Iter` from a generator expression:
         ```python
-        >>> from pyochain import Iter
-        >>> gen_expr = (x * x for x in range(5))
-        >>> Iter(gen_expr).collect(Seq)
-        Seq(0, 1, 4, 9, 16)
+        from pyochain import Iter, Seq
 
+        gen_expr = (x * x for x in range(5))
+        assert Iter(gen_expr).collect(Seq) == Seq([0, 1, 4, 9, 16])
         ```
         Or from a generator function:
         ```python
-        >>> from pyochain import Iter
-        >>> def gen_func():
-        ...     for x in range(5):
-        ...         yield x * x
-        >>>
-        >>> Iter(gen_func()).collect(Seq)
-        Seq(0, 1, 4, 9, 16)
+        from pyochain import Iter
 
+        def gen_func():
+            for x in range(5):
+                yield x * x
+
+        assert Iter(gen_func()).collect(Seq) == Seq([0, 1, 4, 9, 16])
         ```
     """
 
@@ -90,18 +87,18 @@ class Peekable[T](PyoIterator[T]):
         Examples:
             Peek at the next value of an iterator without consuming it.
             ```python
-            >>> from pyochain import Range
-            >>> iterator = Range(0, 5).iter().peekable()
-            >>> # Peek at the first item of the iterator without consuming it.
-            >>> iterator.peek()
-            Some(0)
-            >>> # The next item returned is still 0, as we haven't consumed it yet.
-            >>> iterator.next()
-            Some(0)
-            >>> # Now the next item returned is 1, as we have consumed the first item.
-            >>> iterator.next()
-            Some(1)
+            from pyochain import Range, Some
 
+            iterator = Range(0, 5).iter().peekable()
+
+            # Peek at the first item of the iterator without consuming it.
+            assert iterator.peek() == Some(0)
+
+            # The next item returned is still 0, as we haven't consumed it yet.
+            assert iterator.next() == Some(0)
+
+            # Now the next item returned is 1, as we have consumed the first item.
+            assert iterator.next() == Some(1)
             ```
         """
     def next_if(self, func: Callable[[T], bool]) -> Option[T]:
@@ -116,29 +113,29 @@ class Peekable[T](PyoIterator[T]):
         Examples:
             Consume a number if it's equal to 0.
             ```python
-            >>> from pyochain import Range
-            >>> iterator = Range(0, 5).iter().peekable()
-            >>> # The first item of the iterator is 0; consume it.
-            >>> iterator.next_if(lambda x: x == 0)
-            Some(0)
-            >>> # The next item returned is now 1, so `next_if` will return `None`.
-            >>> iterator.next_if(lambda x: x == 0)
-            NONE
-            >>> # `next_if` retains the next item if the predicate evaluates to `false` for it.
-            >>> iterator.next()
-            Some(1)
+            from pyochain import Range, Some, NONE
 
+            iterator = Range(0, 5).iter().peekable()
+
+            # The first item of the iterator is 0; consume it.
+            assert iterator.next_if(lambda x: x == 0) == Some(0)
+
+            # The next item returned is now 1, so `next_if` will return `None`.
+            assert iterator.next_if(lambda x: x == 0) == NONE
+
+            # `next_if` retains the next item if the predicate evaluates to `false` for it.
+            assert iterator.next() == Some(1)
             ```
             Consume any number less than 10.
             ```python
-            >>> iterator = Range(1, 20).iter().peekable()
-            >>> # Consume all numbers less than 10
-            >>> while iterator.next_if(lambda x: x < 10).is_some():
-            ...     pass
-            >>> # The next value returned will be 10
-            >>> iterator.next()
-            Some(10)
+            iterator = Range(1, 20).iter().peekable()
 
+            # Consume all numbers less than 10
+            while iterator.next_if(lambda x: x < 10).is_some():
+                pass
+
+            # The next value returned will be 10
+            assert iterator.next() == Some(10)
             ```
         """
     def next_if_eq(self, expected: object) -> Option[T]:
@@ -153,18 +150,18 @@ class Peekable[T](PyoIterator[T]):
         Example:
             Consume a number if it's equal to 0.
             ```python
-            >>> from pyochain import Range
-            >>> iterator = Range(0, 5).iter().peekable()
-            >>> # The first item of the iterator is 0; consume it.
-            >>> iterator.next_if_eq(0)
-            Some(0)
-            >>> # The next item returned is now 1, so `next_if_eq` will return `None`.
-            >>> iterator.next_if_eq(0)
-            NONE
-            >>> # `next_if_eq` retains the next item if it was not equal to `expected`.
-            >>> iterator.next()
-            Some(1)
+            from pyochain import Range, Some, NONE
 
+            iterator = Range(0, 5).iter().peekable()
+
+            # The first item of the iterator is 0; consume it.
+            assert iterator.next_if_eq(0) == Some(0)
+
+            # The next item returned is now 1, so `next_if_eq` will return `None`.
+            assert iterator.next_if_eq(0) == NONE
+
+            # `next_if_eq` retains the next item if it was not equal to `expected`.
+            assert iterator.next() == Some(1)
             ```
         """
 
@@ -188,26 +185,25 @@ class Peekable[T](PyoIterator[T]):
         Examples:
             Parse the leading decimal number from an iterator of characters.
             ```python
-            >>> from pyochain import Iter, Option, Some, NONE, Result
-            >>> import unicodedata
-            >>>
-            >>> iterator = Iter("125 GOTO 10").peekable()
-            >>> line_num = 0
-            >>> def try_parse_digit(c: str) -> Result[int, str]:
-            ...     try:
-            ...         res = Some(unicodedata.digit(c))
-            ...     except ValueError as e:
-            ...         res = NONE
-            ...     return res.ok_or(c)
-            >>>
-            >>> digit = iterator.next_if_map(try_parse_digit)
-            >>> while digit.is_some():
-            ...     line_num = line_num * 10 + digit.unwrap()
-            ...     digit = iterator.next_if_map(try_parse_digit)
-            >>> line_num
-            125
-            >>> iterator.join("")
-            ' GOTO 10'
+            from pyochain import Iter, Option, Some, NONE, Result
+            import unicodedata
 
+            iterator = Iter("125 GOTO 10").peekable()
+            line_num = 0
+
+            def try_parse_digit(c: str) -> Result[int, str]:
+                try:
+                    res = Some(unicodedata.digit(c))
+                except ValueError as e:
+                    res = NONE
+                return res.ok_or(c)
+
+            digit = iterator.next_if_map(try_parse_digit)
+            while digit.is_some():
+                line_num = line_num * 10 + digit.unwrap()
+                digit = iterator.next_if_map(try_parse_digit)
+
+            assert line_num == 125
+            assert iterator.join("") == " GOTO 10"
             ```
         """

--- a/pyochain/core/_iterators.pyi
+++ b/pyochain/core/_iterators.pyi
@@ -113,7 +113,7 @@ class Peekable[T](PyoIterator[T]):
         Examples:
             Consume a number if it's equal to 0.
             ```python
-            from pyochain import Range, Some, NONE
+            from pyochain import Range, Some
 
             iterator = Range(0, 5).iter().peekable()
 
@@ -121,7 +121,7 @@ class Peekable[T](PyoIterator[T]):
             assert iterator.next_if(lambda x: x == 0) == Some(0)
 
             # The next item returned is now 1, so `next_if` will return `None`.
-            assert iterator.next_if(lambda x: x == 0) == NONE
+            assert iterator.next_if(lambda x: x == 0).is_none()
 
             # `next_if` retains the next item if the predicate evaluates to `false` for it.
             assert iterator.next() == Some(1)
@@ -150,7 +150,7 @@ class Peekable[T](PyoIterator[T]):
         Example:
             Consume a number if it's equal to 0.
             ```python
-            from pyochain import Range, Some, NONE
+            from pyochain import Range, Some
 
             iterator = Range(0, 5).iter().peekable()
 
@@ -158,7 +158,7 @@ class Peekable[T](PyoIterator[T]):
             assert iterator.next_if_eq(0) == Some(0)
 
             # The next item returned is now 1, so `next_if_eq` will return `None`.
-            assert iterator.next_if_eq(0) == NONE
+            assert iterator.next_if_eq(0).is_none()
 
             # `next_if_eq` retains the next item if it was not equal to `expected`.
             assert iterator.next() == Some(1)

--- a/pyochain/core/_option.pyi
+++ b/pyochain/core/_option.pyi
@@ -281,9 +281,8 @@ class OptionType[T](Pipe):
 
             assert Some(42) == Some(42)
             assert Some(42) != Some(21)
-            assert Some(42).is_some()
-            assert NONE.is_none()
-            assert NONE == None
+            assert Some(42) != NONE
+            assert NONE == NONE
             assert Some(42) != 42
             ```
         """

--- a/pyochain/core/_option.pyi
+++ b/pyochain/core/_option.pyi
@@ -166,7 +166,7 @@ class OptionType[T](Pipe):
             from pyochain import Some, NONE
 
             assert Some((2, 3)).map_star(lambda x, y: x + y) == Some(5)
-            assert NONE.map_star(lambda x, y: x + y) == NONE
+            assert NONE.map_star(lambda x, y: x + y).is_none()
             ```
         """
 
@@ -236,7 +236,7 @@ class OptionType[T](Pipe):
             from pyochain import Some, NONE
 
             assert Some((2, 3)).and_then_star(lambda x, y: Some(x + y)) == Some(5)
-            assert NONE.and_then_star(lambda x, y: Some(x + y)) == NONE
+            assert NONE.and_then_star(lambda x, y: Some(x + y)).is_none()
             ```
         """
 
@@ -253,10 +253,10 @@ class OptionType[T](Pipe):
             ```python
             from pyochain import Some, NONE
 
-            assert Some(42).ne(Some(21)) == True
-            assert Some(42).ne(Some(42)) == False
-            assert Some(42).ne(NONE) == True
-            assert NONE.ne(NONE) == False
+            assert Some(42).ne(Some(21))
+            assert not Some(42).ne(Some(42))
+            assert Some(42).ne(NONE)
+            assert not NONE.ne(NONE)
             ```
         """
 
@@ -281,8 +281,8 @@ class OptionType[T](Pipe):
 
             assert Some(42) == Some(42)
             assert Some(42) != Some(21)
-            assert Some(42) != NONE
-            assert NONE == NONE
+            assert Some(42).is_some()
+            assert NONE.is_none()
             assert NONE == None
             assert Some(42) != 42
             ```
@@ -349,16 +349,16 @@ class OptionType[T](Pipe):
             from pyochain import Some, NONE
 
             x = Some(2)
-            assert x.is_some_and(lambda x: x > 1) == True
+            assert x.is_some_and(lambda x: x > 1)
 
             x = Some(0)
-            assert x.is_some_and(lambda x: x > 1) == False
+            assert not x.is_some_and(lambda x: x > 1)
 
             x = NONE
-            assert x.is_some_and(lambda x: x > 1) == False
+            assert not x.is_some_and(lambda x: x > 1)
 
             x = Some("hello")
-            assert x.is_some_and(lambda x: len(x) > 1) == True
+            assert x.is_some_and(lambda x: len(x) > 1)
             ```
         """
 
@@ -373,10 +373,10 @@ class OptionType[T](Pipe):
             from pyochain import Some, NONE
 
             x = Some(2)
-            assert x.is_none() == False
+            assert not x.is_none()
             y = NONE
 
-            assert y.is_none() == True
+            assert y.is_none()
             ```
         """
 
@@ -397,10 +397,10 @@ class OptionType[T](Pipe):
             ```python
             from pyochain import Some, NONE
 
-            assert Some(2).is_none_or(lambda x: x > 1) == True
-            assert Some(0).is_none_or(lambda x: x > 1) == False
-            assert NONE.is_none_or(lambda x: x > 1) == True
-            assert Some("hello").is_none_or(lambda x: len(x) > 1) == True
+            assert Some(2).is_none_or(lambda x: x > 1)
+            assert not Some(0).is_none_or(lambda x: x > 1)
+            assert NONE.is_none_or(lambda x: x > 1)
+            assert Some("hello").is_none_or(lambda x: len(x) > 1)
             ```
         """
 
@@ -508,7 +508,7 @@ class OptionType[T](Pipe):
             from pyochain import Some, NONE
 
             assert Some("Hello, World!").map(len) == Some(13)
-            assert NONE.map(len) == NONE
+            assert NONE.map(len).is_none()
             ```
         """
 
@@ -549,7 +549,7 @@ class OptionType[T](Pipe):
             assert Some(2).or_(NONE) == Some(2)
             assert NONE.or_(Some(100)) == Some(100)
             assert Some(2).or_(Some(100)) == Some(2)
-            assert NONE.or_(NONE) == NONE
+            assert NONE.or_(NONE).is_none()
             ```
         """
 
@@ -580,9 +580,9 @@ class OptionType[T](Pipe):
                 return NONE
 
             assert Some(2).and_then(sq).and_then(sq) == Some(16)
-            assert Some(2).and_then(sq).and_then(nope) == NONE
-            assert Some(2).and_then(nope).and_then(sq) == NONE
-            assert NONE.and_then(sq).and_then(sq) == NONE
+            assert Some(2).and_then(sq).and_then(nope).is_none()
+            assert Some(2).and_then(nope).and_then(sq).is_none()
+            assert NONE.and_then(sq).and_then(sq).is_none()
             ```
         """
 
@@ -607,7 +607,7 @@ class OptionType[T](Pipe):
 
             assert Some("barbarians").or_else(vikings) == Some("barbarians")
             assert NONE.or_else(vikings) == Some("vikings")
-            assert NONE.or_else(nobody) == NONE
+            assert NONE.or_else(nobody).is_none()
             ```
         """
 
@@ -721,8 +721,8 @@ class OptionType[T](Pipe):
             def is_even(n: int) -> bool:
                 return n % 2 == 0
 
-            assert NONE.filter(is_even) == NONE
-            assert Some(3).filter(is_even) == NONE
+            assert NONE.filter(is_even).is_none()
+            assert Some(3).filter(is_even).is_none()
             assert Some(4).filter(is_even) == Some(4)
             ```
         """
@@ -743,7 +743,7 @@ class OptionType[T](Pipe):
             from pyochain import Some, NONE
 
             assert Some(42).iter().next() == Some(42)
-            assert NONE.iter().next() == NONE
+            assert NONE.iter().next().is_none()
             ```
         """
     def inspect[**P](
@@ -770,7 +770,7 @@ class OptionType[T](Pipe):
             assert Some(2).inspect(lambda x: seen.append(x)) == Some(2)
             assert seen == Vec([2])
 
-            assert NONE.inspect(lambda x: seen.append(x)) == NONE
+            assert NONE.inspect(lambda x: seen.append(x)).is_none()
             assert seen == Vec([2])
             ```
         """
@@ -807,8 +807,8 @@ class OptionType[T](Pipe):
             from pyochain import Some, NONE
 
             assert Some(1).zip(Some("a")) == Some((1, "a"))
-            assert Some(1).zip(NONE) == NONE
-            assert NONE.zip(Some("a")) == NONE
+            assert Some(1).zip(NONE).is_none()
+            assert NONE.zip(Some("a")).is_none()
             ```
         """
 
@@ -840,8 +840,8 @@ class OptionType[T](Pipe):
             y = Some(42.7)
 
             assert x.zip_with(y, Point) == Some(Point(x=17.5, y=42.7))
-            assert x.zip_with(NONE, Point) == NONE
-            assert NONE.zip_with(y, Point) == NONE
+            assert x.zip_with(NONE, Point).is_none()
+            assert NONE.zip_with(y, Point).is_none()
             ```
         """
 
@@ -903,7 +903,7 @@ class OptionType[T](Pipe):
             from pyochain import Some, Ok, Err, NONE
 
             assert Some(Ok(5)).transpose().unwrap().unwrap() == 5
-            assert NONE.transpose().unwrap() == NONE
+            assert NONE.transpose().unwrap().is_none()
             assert Some(Err("error")).transpose().unwrap_err() == "error"
             ```
         """
@@ -923,9 +923,9 @@ class OptionType[T](Pipe):
 
             assert Some(2).xor(NONE).unwrap() == 2
             assert NONE.xor(Some(2)).unwrap() == 2
-            assert Some(2).xor(Some(2)) == NONE
-            assert NONE.xor(NONE) == NONE
-            assert Some("hello").xor(Some(1)) == NONE
+            assert Some(2).xor(Some(2)).is_none()
+            assert NONE.xor(NONE).is_none()
+            assert Some("hello").xor(Some(1)).is_none()
             ```
         """
     def unwrap_or_none(self) -> T | None:
@@ -1037,6 +1037,6 @@ def option[T](value: T | None) -> Option[T]:
         from pyochain import option, Some, NONE
 
         assert option(42) == Some(42)
-        assert option(None) == NONE
+        assert option(None).is_none()
         ```
     """

--- a/pyochain/core/_option.pyi
+++ b/pyochain/core/_option.pyi
@@ -163,12 +163,10 @@ class OptionType[T](Pipe):
 
         Example:
             ```python
-            >>> from pyochain import Some, NONE
-            >>> Some((2, 3)).map_star(lambda x, y: x + y)
-            Some(5)
-            >>> NONE.map_star(lambda x, y: x + y)
-            NONE
+            from pyochain import Some, NONE
 
+            assert Some((2, 3)).map_star(lambda x, y: x + y) == Some(5)
+            assert NONE.map_star(lambda x, y: x + y) == NONE
             ```
         """
 
@@ -235,12 +233,10 @@ class OptionType[T](Pipe):
 
         Example:
             ```python
-            >>> from pyochain import Some, NONE
-            >>> Some((2, 3)).and_then_star(lambda x, y: Some(x + y))
-            Some(5)
-            >>> NONE.and_then_star(lambda x, y: Some(x + y))
-            NONE
+            from pyochain import Some, NONE
 
+            assert Some((2, 3)).and_then_star(lambda x, y: Some(x + y)) == Some(5)
+            assert NONE.and_then_star(lambda x, y: Some(x + y)) == NONE
             ```
         """
 
@@ -255,16 +251,12 @@ class OptionType[T](Pipe):
 
         Example:
             ```python
-            >>> from pyochain import Some, NONE
-            >>> Some(42).ne(Some(21))
-            True
-            >>> Some(42).ne(Some(42))
-            False
-            >>> Some(42).ne(NONE)
-            True
-            >>> NONE.ne(NONE)
-            False
+            from pyochain import Some, NONE
 
+            assert Some(42).ne(Some(21)) == True
+            assert Some(42).ne(Some(42)) == False
+            assert Some(42).ne(NONE) == True
+            assert NONE.ne(NONE) == False
             ```
         """
 
@@ -354,21 +346,19 @@ class OptionType[T](Pipe):
 
         Example:
             ```python
-            >>> from pyochain import Some, NONE
-            >>> x = Some(2)
-            >>> x.is_some_and(lambda x: x > 1)
-            True
+            from pyochain import Some, NONE
 
-            >>> x = Some(0)
-            >>> x.is_some_and(lambda x: x > 1)
-            False
-            >>> x = NONE
-            >>> x.is_some_and(lambda x: x > 1)
-            False
-            >>> x = Some("hello")
-            >>> x.is_some_and(lambda x: len(x) > 1)
-            True
+            x = Some(2)
+            assert x.is_some_and(lambda x: x > 1) == True
 
+            x = Some(0)
+            assert x.is_some_and(lambda x: x > 1) == False
+
+            x = NONE
+            assert x.is_some_and(lambda x: x > 1) == False
+
+            x = Some("hello")
+            assert x.is_some_and(lambda x: len(x) > 1) == True
             ```
         """
 
@@ -380,15 +370,13 @@ class OptionType[T](Pipe):
 
         Example:
             ```python
-            >>> from pyochain import Some, NONE
-            >>>
-            >>> x = Some(2)
-            >>> x.is_none()
-            False
-            >>> y = NONE
-            >>> y.is_none()
-            True
+            from pyochain import Some, NONE
 
+            x = Some(2)
+            assert x.is_none() == False
+            y = NONE
+
+            assert y.is_none() == True
             ```
         """
 
@@ -407,16 +395,12 @@ class OptionType[T](Pipe):
 
         Example:
             ```python
-            >>> from pyochain import Some, NONE
-            >>> Some(2).is_none_or(lambda x: x > 1)
-            True
-            >>> Some(0).is_none_or(lambda x: x > 1)
-            False
-            >>> NONE.is_none_or(lambda x: x > 1)
-            True
-            >>> Some("hello").is_none_or(lambda x: len(x) > 1)
-            True
+            from pyochain import Some, NONE
 
+            assert Some(2).is_none_or(lambda x: x > 1) == True
+            assert Some(0).is_none_or(lambda x: x > 1) == False
+            assert NONE.is_none_or(lambda x: x > 1) == True
+            assert Some("hello").is_none_or(lambda x: len(x) > 1) == True
             ```
         """
 
@@ -476,12 +460,10 @@ class OptionType[T](Pipe):
 
         Example:
             ```python
-            >>> from pyochain import Some, NONE
-            >>> Some("car").unwrap_or("bike")
-            'car'
-            >>> NONE.unwrap_or("bike")
-            'bike'
+            from pyochain import Some, NONE
 
+            assert Some("car").unwrap_or("bike") == "car"
+            assert NONE.unwrap_or("bike") == "bike"
             ```
         """
 
@@ -496,13 +478,12 @@ class OptionType[T](Pipe):
 
         Example:
             ```python
-            >>> from pyochain import Some, NONE
-            >>> k = 10
-            >>> Some(4).unwrap_or_else(lambda: 2 * k)
-            4
-            >>> NONE.unwrap_or_else(lambda: 2 * k)
-            20
+            from pyochain import Some, NONE
 
+            k = 10
+
+            assert Some(4).unwrap_or_else(lambda: 2 * k) == 4
+            assert NONE.unwrap_or_else(lambda: 2 * k) == 20
             ```
         """
 
@@ -524,12 +505,10 @@ class OptionType[T](Pipe):
 
         Example:
             ```python
-            >>> from pyochain import Some, NONE
-            >>> Some("Hello, World!").map(len)
-            Some(13)
-            >>> NONE.map(len)
-            NONE
+            from pyochain import Some, NONE
 
+            assert Some("Hello, World!").map(len) == Some(13)
+            assert NONE.map(len) == NONE
             ```
         """
 
@@ -565,16 +544,12 @@ class OptionType[T](Pipe):
 
         Example:
             ```python
-            >>> from pyochain import Some, NONE
-            >>> Some(2).or_(NONE)
-            Some(2)
-            >>> NONE.or_(Some(100))
-            Some(100)
-            >>> Some(2).or_(Some(100))
-            Some(2)
-            >>> NONE.or_(NONE)
-            NONE
+            from pyochain import Some, NONE
 
+            assert Some(2).or_(NONE) == Some(2)
+            assert NONE.or_(Some(100)) == Some(100)
+            assert Some(2).or_(Some(100)) == Some(2)
+            assert NONE.or_(NONE) == NONE
             ```
         """
 
@@ -596,21 +571,18 @@ class OptionType[T](Pipe):
 
         Example:
             ```python
-            >>> from pyochain import Some, NONE, Option
-            >>>
-            >>> def sq(x: int) -> Option[int]:
-            ...     return Some(x * x)
-            >>> def nope(x: int) -> Option[int]:
-            ...     return NONE
-            >>> Some(2).and_then(sq).and_then(sq)
-            Some(16)
-            >>> Some(2).and_then(sq).and_then(nope)
-            NONE
-            >>> Some(2).and_then(nope).and_then(sq)
-            NONE
-            >>> NONE.and_then(sq).and_then(sq)
-            NONE
+            from pyochain import Some, NONE, Option
 
+            def sq(x: int) -> Option[int]:
+                return Some(x * x)
+
+            def nope(x: int) -> Option[int]:
+                return NONE
+
+            assert Some(2).and_then(sq).and_then(sq) == Some(16)
+            assert Some(2).and_then(sq).and_then(nope) == NONE
+            assert Some(2).and_then(nope).and_then(sq) == NONE
+            assert NONE.and_then(sq).and_then(sq) == NONE
             ```
         """
 
@@ -625,18 +597,17 @@ class OptionType[T](Pipe):
 
         Example:
             ```python
-            >>> from pyochain import Some, NONE, Option
-            >>> def nobody() -> Option[str]:
-            ...     return NONE
-            >>> def vikings() -> Option[str]:
-            ...     return Some("vikings")
-            >>> Some("barbarians").or_else(vikings)
-            Some('barbarians')
-            >>> NONE.or_else(vikings)
-            Some('vikings')
-            >>> NONE.or_else(nobody)
-            NONE
+            from pyochain import Some, NONE, Option
 
+            def nobody() -> Option[str]:
+                return NONE
+
+            def vikings() -> Option[str]:
+                return Some("vikings")
+
+            assert Some("barbarians").or_else(vikings) == Some("barbarians")
+            assert NONE.or_else(vikings) == Some("vikings")
+            assert NONE.or_else(nobody) == NONE
             ```
         """
 
@@ -651,12 +622,10 @@ class OptionType[T](Pipe):
 
         Example:
             ```python
-            >>> from pyochain import Some, NONE
-            >>> Some(1).ok_or("fail")
-            Ok(1)
-            >>> NONE.ok_or("fail")
-            Err('fail')
+            from pyochain import Some, NONE, Ok
 
+            assert Some(1).ok_or("fail").unwrap() == 1
+            assert NONE.ok_or("fail").unwrap_err() == "fail"
             ```
         """
 
@@ -671,12 +640,10 @@ class OptionType[T](Pipe):
 
         Example:
             ```python
-            >>> from pyochain import Some, NONE
-            >>> Some(1).ok_or_else(lambda: "fail")
-            Ok(1)
-            >>> NONE.ok_or_else(lambda: "fail")
-            Err('fail')
+            from pyochain import Some, NONE, Ok, Err
 
+            assert Some(1).ok_or_else(lambda: "fail").unwrap() == 1
+            assert NONE.ok_or_else(lambda: "fail").unwrap_err() == "fail"
             ```
         """
 
@@ -700,12 +667,10 @@ class OptionType[T](Pipe):
 
         Example:
             ```python
-            >>> from pyochain import Some, NONE
-            >>> Some(2).map_or(0, lambda x: x * 10)
-            20
-            >>> NONE.map_or(0, lambda x: x * 10)
-            0
+            from pyochain import Some, NONE
 
+            assert Some(2).map_or(0, lambda x: x * 10) == 20
+            assert NONE.map_or(0, lambda x: x * 10) == 0
             ```
         """
 
@@ -721,12 +686,10 @@ class OptionType[T](Pipe):
 
         Example:
             ```python
-            >>> from pyochain import Some, NONE
-            >>> Some(2).map_or_else(lambda: 0, lambda x: x * 10)
-            20
-            >>> NONE.map_or_else(lambda: 0, lambda x: x * 10)
-            0
+            from pyochain import Some, NONE
 
+            assert Some(2).map_or_else(lambda: 0, lambda x: x * 10) == 20
+            assert NONE.map_or_else(lambda: 0, lambda x: x * 10) == 0
             ```
         """
 
@@ -753,18 +716,14 @@ class OptionType[T](Pipe):
 
         Example:
             ```python
-            >>> from pyochain import Some, NONE
-            >>>
-            >>> def is_even(n: int) -> bool:
-            ...     return n % 2 == 0
-            >>>
-            >>> NONE.filter(is_even)
-            NONE
-            >>> Some(3).filter(is_even)
-            NONE
-            >>> Some(4).filter(is_even)
-            Some(4)
+            from pyochain import Some, NONE
 
+            def is_even(n: int) -> bool:
+                return n % 2 == 0
+
+            assert NONE.filter(is_even) == NONE
+            assert Some(3).filter(is_even) == NONE
+            assert Some(4).filter(is_even) == Some(4)
             ```
         """
 
@@ -781,12 +740,10 @@ class OptionType[T](Pipe):
 
         Example:
             ```python
-            >>> from pyochain import Some, NONE
-            >>> Some(42).iter().next()
-            Some(42)
-            >>> NONE.iter().next()
-            NONE
+            from pyochain import Some, NONE
 
+            assert Some(42).iter().next() == Some(42)
+            assert NONE.iter().next() == NONE
             ```
         """
     def inspect[**P](
@@ -806,17 +763,15 @@ class OptionType[T](Pipe):
 
         Example:
             ```python
-            >>> from pyochain import Some, NONE, Vec
-            >>> seen = Vec[int](())
-            >>> Some(2).inspect(lambda x: seen.append(x))
-            Some(2)
-            >>> seen
-            Vec(2)
-            >>> NONE.inspect(lambda x: seen.append(x))
-            NONE
-            >>> seen
-            Vec(2)
+            from pyochain import Some, NONE, Vec
 
+            seen = Vec[int]([])
+
+            assert Some(2).inspect(lambda x: seen.append(x)) == Some(2)
+            assert seen == Vec([2])
+
+            assert NONE.inspect(lambda x: seen.append(x)) == NONE
+            assert seen == Vec([2])
             ```
         """
 
@@ -831,12 +786,10 @@ class OptionType[T](Pipe):
 
         Example:
             ```python
-            >>> from pyochain import Some, NONE
-            >>> Some((1, "a")).unzip()
-            (Some(1), Some('a'))
-            >>> NONE.unzip()
-            (NONE, NONE)
+            from pyochain import Some, NONE
 
+            assert Some((1, "a")).unzip() == (Some(1), Some("a"))
+            assert NONE.unzip() == (NONE, NONE)
             ```
         """
 
@@ -851,14 +804,11 @@ class OptionType[T](Pipe):
 
         Example:
             ```python
-            >>> from pyochain import Some, NONE
-            >>> Some(1).zip(Some("a"))
-            Some((1, 'a'))
-            >>> Some(1).zip(NONE)
-            NONE
-            >>> NONE.zip(Some("a"))
-            NONE
+            from pyochain import Some, NONE
 
+            assert Some(1).zip(Some("a")) == Some((1, "a"))
+            assert Some(1).zip(NONE) == NONE
+            assert NONE.zip(Some("a")) == NONE
             ```
         """
 
@@ -878,23 +828,20 @@ class OptionType[T](Pipe):
 
         Example:
             ```python
-            >>> from dataclasses import dataclass
-            >>> from pyochain import Some, NONE
-            >>>
-            >>> @dataclass
-            ... class Point:
-            ...     x: float
-            ...     y: float
-            >>>
-            >>> x = Some(17.5)
-            >>> y = Some(42.7)
-            >>> x.zip_with(y, Point)
-            Some(Point(x=17.5, y=42.7))
-            >>> x.zip_with(NONE, Point)
-            NONE
-            >>> NONE.zip_with(y, Point)
-            NONE
+            from dataclasses import dataclass
+            from pyochain import Some, NONE
 
+            @dataclass
+            class Point:
+                x: float
+                y: float
+
+            x = Some(17.5)
+            y = Some(42.7)
+
+            assert x.zip_with(y, Point) == Some(Point(x=17.5, y=42.7))
+            assert x.zip_with(NONE, Point) == NONE
+            assert NONE.zip_with(y, Point) == NONE
             ```
         """
 
@@ -953,14 +900,11 @@ class OptionType[T](Pipe):
 
         Example:
             ```python
-            >>> from pyochain import Some, Ok, Err, NONE
-            >>> Some(Ok(5)).transpose()
-            Ok(Some(5))
-            >>> NONE.transpose()
-            Ok(NONE)
-            >>> Some(Err("error")).transpose()
-            Err('error')
+            from pyochain import Some, Ok, Err, NONE
 
+            assert Some(Ok(5)).transpose().unwrap().unwrap() == 5
+            assert NONE.transpose().unwrap() == NONE
+            assert Some(Err("error")).transpose().unwrap_err() == "error"
             ```
         """
 
@@ -975,18 +919,13 @@ class OptionType[T](Pipe):
 
         Example:
             ```python
-            >>> from pyochain import Some, NONE
-            >>> Some(2).xor(NONE)
-            Some(2)
-            >>> NONE.xor(Some(2))
-            Some(2)
-            >>> Some(2).xor(Some(2))
-            NONE
-            >>> NONE.xor(NONE)
-            NONE
-            >>> Some("hello").xor(Some(1))
-            NONE
+            from pyochain import Some, NONE
 
+            assert Some(2).xor(NONE).unwrap() == 2
+            assert NONE.xor(Some(2)).unwrap() == 2
+            assert Some(2).xor(Some(2)) == NONE
+            assert NONE.xor(NONE) == NONE
+            assert Some("hello").xor(Some(1)) == NONE
             ```
         """
     def unwrap_or_none(self) -> T | None:
@@ -1003,12 +942,10 @@ class OptionType[T](Pipe):
 
         Example:
             ```python
-            >>> from pyochain import Option, Some, NONE
-            >>> NONE.unwrap_or_none() is None
-            True
-            >>> Some(42).unwrap_or_none()
-            42
+            from pyochain import Option, Some, NONE
 
+            assert NONE.unwrap_or_none() is None
+            assert Some(42).unwrap_or_none() == 42
             ```
         """
 
@@ -1097,11 +1034,9 @@ def option[T](value: T | None) -> Option[T]:
 
     Example:
         ```python
-        >>> from pyochain import option
-        >>> option(42)
-        Some(42)
-        >>> option(None)
-        NONE
+        from pyochain import option, Some, NONE
 
+        assert option(42) == Some(42)
+        assert option(None) == NONE
         ```
     """

--- a/pyochain/core/_result.pyi
+++ b/pyochain/core/_result.pyi
@@ -298,7 +298,7 @@ class ResultType[T, E](Pipe, Protocol):
         Returns:
             Result[R, E]: The result of the function if `Ok`, otherwise the original `Err`.
 
-        Exam    ple:
+        Example:
             ```python
             from pyochain import Ok, Err, Result
 

--- a/pyochain/core/_result.pyi
+++ b/pyochain/core/_result.pyi
@@ -16,18 +16,15 @@ def then_if_true[T](value: T, *, predicate: Callable[[T], bool]) -> Option[T]:
 
     Example:
         ```python
-        >>> from pyochain import then_if_true
-        >>> then_if_true(42, predicate=lambda x: x == 42)
-        Some(42)
-        >>> then_if_true(21, predicate=lambda x: x == 42)
-        NONE
-        >>> from pathlib import Path
-        >>> readme_path = then_if_true(Path("README.md"), predicate=Path.exists).map(
-        ...     str
-        ... )
-        >>> readme_path
-        Some('README.md')
+        from pyochain import then_if_true, Some, NONE
 
+        assert then_if_true(42, predicate=lambda x: x == 42) == Some(42)
+        assert then_if_true(21, predicate=lambda x: x == 42) == NONE
+
+        from pathlib import Path
+
+        readme_path = then_if_true(Path("README.md"), predicate=Path.exists).map(str)
+        assert readme_path == Some("README.md")
         ```
     """
 
@@ -42,18 +39,13 @@ def then_if_some[T](value: T) -> Option[T]:
 
     Example:
         ```python
-        >>> from pyochain import then_if_some
-        >>> then_if_some(42)
-        Some(42)
-        >>> then_if_some(0)
-        NONE
-        >>> then_if_some("hello")
-        Some('hello')
-        >>> then_if_some("")
-        NONE
-        >>> then_if_some(())  # Empty sequence is falsy
-        NONE
+        from pyochain import then_if_some, Some, NONE
 
+        assert then_if_some(42) == Some(42)
+        assert then_if_some(0) == NONE
+        assert then_if_some("hello") == Some("hello")
+        assert then_if_some("") == NONE
+        assert then_if_some(()) == NONE  # Empty sequence is falsy
         ```
     """
 
@@ -94,26 +86,29 @@ class ResultType[T, E](Pipe, Protocol):
 
     Example:
         ```python
-        >>> from pyochain import Err, Ok, Result
-        >>>
-        >>> def is_positive(x: int) -> Result[str, ValueError]:
-        ...     if x > 0:
-        ...         return Ok(f"Value is {x}")
-        ...     msg = f"{x} is not positive"
-        ...     return Err(ValueError(msg))
-        >>>
-        >>> def handle_variant(x: Result[str, ValueError]) -> str:
-        ...     match x:
-        ...         case Ok(value):
-        ...             return f"Success: {value}"
-        ...         case Err(error):
-        ...             return f"Failure: {error}"
-        >>>
-        >>> is_positive(5).map(lambda s: s.upper()).pipe(handle_variant)
-        'Success: VALUE IS 5'
-        >>> is_positive(-3).map(lambda s: s.upper()).pipe(handle_variant)
-        'Failure: -3 is not positive'
+        from pyochain import Err, Ok, Result
 
+        def is_positive(x: int) -> Result[str, ValueError]:
+            if x > 0:
+                return Ok(f"Value is {x}")
+            msg = f"{x} is not positive"
+            return Err(ValueError(msg))
+
+        def handle_variant(x: Result[str, ValueError]) -> str:
+            match x:
+                case Ok(value):
+                    return f"Success: {value}"
+                case Err(error):
+                    return f"Failure: {error}"
+
+        assert (
+            is_positive(5).map(lambda s: s.upper()).pipe(handle_variant)
+            == "Success: VALUE IS 5"
+        )
+        assert (
+            is_positive(-3).map(lambda s: s.upper()).pipe(handle_variant)
+            == "Failure: -3 is not positive"
+        )
         ```
     """
 
@@ -127,12 +122,10 @@ class ResultType[T, E](Pipe, Protocol):
 
         Example:
             ```python
-            >>> from pyochain import Ok, Err
-            >>> Ok(2).swap()
-            Err(2)
-            >>> Err("error").swap()
-            Ok('error')
+            from pyochain import Ok, Err
 
+            assert Ok(2).swap().unwrap_err() == 2
+            assert Err("error").swap().unwrap() == "error"
             ```
         """
     def flatten[T1, E1, E2](self: ResultType[Result[T1, E1], E2]) -> Result[T1, E1]:
@@ -147,14 +140,13 @@ class ResultType[T, E](Pipe, Protocol):
 
         Example:
             ```python
-            >>> from pyochain import Result, Ok, Err
-            >>> nested_ok: Result[Result[int, str], str] = Ok(Ok(2))
-            >>> nested_ok.flatten()
-            Ok(2)
-            >>> nested_err: Result[Result[int, str], str] = Ok(Err("inner error"))
-            >>> nested_err.flatten()
-            Err('inner error')
+            from pyochain import Result, Ok, Err
 
+            nested_ok: Result[Result[int, str], str] = Ok(Ok(2))
+            assert nested_ok.flatten().unwrap() == 2
+
+            nested_err: Result[Result[int, str], str] = Ok(Err("inner error"))
+            assert nested_err.flatten().unwrap_err() == "inner error"
             ```
         """
 
@@ -166,12 +158,10 @@ class ResultType[T, E](Pipe, Protocol):
 
         Example:
             ```python
-            >>> from pyochain import Ok, Err
-            >>> Ok(7).iter().next()
-            Some(7)
-            >>> Err("nothing!").iter().next()
-            NONE
+            from pyochain import Ok, Err, Some, NONE
 
+            assert Ok(7).iter().next() == Some(7)
+            assert Err("nothing!").iter().next() == NONE
             ```
         """
 
@@ -241,12 +231,10 @@ class ResultType[T, E](Pipe, Protocol):
 
         Example:
             ```python
-            >>> from pyochain import Ok, Err
-            >>> Ok((2, 3)).map_star(lambda x, y: x + y)
-            Ok(5)
-            >>> Err("error").map_star(lambda x, y: x + y)
-            Err('error')
+            from pyochain import Ok, Err
 
+            assert Ok((2, 3)).map_star(lambda x, y: x + y).unwrap() == 5
+            assert Err("error").map_star(lambda x, y: x + y).unwrap_err() == "error"
             ```
         """
 
@@ -313,16 +301,15 @@ class ResultType[T, E](Pipe, Protocol):
         Returns:
             Result[R, E]: The result of the function if `Ok`, otherwise the original `Err`.
 
-        Example:
+        Exam    ple:
             ```python
-            >>> from pyochain import Ok, Err, Result
-            >>> def to_str(x: int, y: int) -> Result[str, str]:
-            ...     return Ok(f"{x},{y}")
-            >>> Ok((2, 3)).and_then_star(to_str)
-            Ok('2,3')
-            >>> Err("error").and_then_star(to_str)
-            Err('error')
+            from pyochain import Ok, Err, Result
 
+            def to_str(x: int, y: int) -> Result[str, str]:
+                return Ok(f"{x},{y}")
+
+            assert Ok((2, 3)).and_then_star(to_str).unwrap() == "2,3"
+            assert Err("error").and_then_star(to_str).unwrap_err() == "error"
             ```
         """
 
@@ -334,14 +321,13 @@ class ResultType[T, E](Pipe, Protocol):
 
         Example:
             ```python
-            >>> from pyochain import Ok, Err, Result
-            >>> x: Result[int, str] = Ok(2)
-            >>> x.is_ok()
-            True
-            >>> y: Result[int, str] = Err("Some error message")
-            >>> y.is_ok()
-            False
+            from pyochain import Ok, Err, Result
 
+            x: Result[int, str] = Ok(2)
+            assert x.is_ok() == True
+
+            y: Result[int, str] = Err("Some error message")
+            assert y.is_ok() == False
             ```
         """
 
@@ -353,14 +339,13 @@ class ResultType[T, E](Pipe, Protocol):
 
         Example:
             ```python
-            >>> from pyochain import Ok, Err, Result
-            >>> x: Result[int, str] = Ok(2)
-            >>> x.is_err()
-            False
-            >>> y: Result[int, str] = Err("Some error message")
-            >>> y.is_err()
-            True
+            from pyochain import Ok, Err, Result
 
+            x: Result[int, str] = Ok(2)
+            assert x.is_err() == False
+
+            y: Result[int, str] = Err("Some error message")
+            assert y.is_err() == True
             ```
         """
 
@@ -395,10 +380,9 @@ class ResultType[T, E](Pipe, Protocol):
 
         Example:
             ```python
-            >>> from pyochain import Err
-            >>> Err("emergency failure").unwrap_err()
-            'emergency failure'
+            from pyochain import Err
 
+            assert Err("emergency failure").unwrap_err() == "emergency failure"
             ```
             ```python
             from pyochain import Ok, ResultUnwrapError
@@ -513,12 +497,10 @@ class ResultType[T, E](Pipe, Protocol):
 
         Example:
             ```python
-            >>> from pyochain import Ok, Err
-            >>> Ok(2).unwrap_or_else(len)
-            2
-            >>> Err("foo").unwrap_or_else(len)
-            3
+            from pyochain import Ok, Err
 
+            assert Ok(2).unwrap_or_else(len) == 2
+            assert Err("foo").unwrap_or_else(len) == 3
             ```
         """
 
@@ -540,12 +522,10 @@ class ResultType[T, E](Pipe, Protocol):
 
         Example:
             ```python
-            >>> from pyochain import Ok, Err
-            >>> Ok(2).map(lambda x: x * 2)
-            Ok(4)
-            >>> Err("error").map(lambda x: x * 2)
-            Err('error')
+            from pyochain import Ok, Err
 
+            assert Ok(2).map(lambda x: x * 2).unwrap() == 4
+            assert Err("error").map(lambda x: x * 2).unwrap_err() == "error"
             ```
         """
 
@@ -568,12 +548,10 @@ class ResultType[T, E](Pipe, Protocol):
 
         Example:
             ```python
-            >>> from pyochain import Ok, Err
-            >>> Ok(2).map_err(len)
-            Ok(2)
-            >>> Err("foo").map_err(len)
-            Err(3)
+            from pyochain import Ok, Err
 
+            assert Ok(2).map_err(len).unwrap() == 2
+            assert Err("foo").map_err(len).unwrap_err() == 3
             ```
         """
     def inspect[**P](
@@ -594,13 +572,11 @@ class ResultType[T, E](Pipe, Protocol):
 
         Example:
             ```python
-            >>> from pyochain import Ok, Vec
-            >>> seen = Vec[int](())
-            >>> Ok(2).inspect(lambda x: seen.append(x))
-            Ok(2)
-            >>> seen
-            Vec(2)
+            from pyochain import Ok, Vec
 
+            seen = Vec[int](())
+            assert Ok(2).inspect(lambda x: seen.append(x)).unwrap() == 2
+            assert seen == Vec([2])
             ```
         """
 
@@ -622,13 +598,13 @@ class ResultType[T, E](Pipe, Protocol):
 
         Example:
             ```python
-            >>> from pyochain import Err, Vec
-            >>> seen = Vec[str](())
-            >>> Err("oops").inspect_err(lambda e: seen.append(e))
-            Err('oops')
-            >>> seen
-            Vec('oops')
+            from pyochain import Err, Vec
 
+            seen = Vec[str](())
+            assert (
+                Err("oops").inspect_err(lambda e: seen.append(e)).unwrap_err() == "oops"
+            )
+            assert seen == Vec(["oops"])
             ```
         """
 
@@ -645,26 +621,23 @@ class ResultType[T, E](Pipe, Protocol):
 
         Example:
             ```python
-            >>> from pyochain import Ok, Err
-            >>> x = Ok(2)
-            >>> y = Err("late error")
-            >>> x.and_(y)
-            Err('late error')
-            >>> x = Err("early error")
-            >>> y = Ok("foo")
-            >>> x.and_(y)
-            Err('early error')
+            from pyochain import Ok, Err
 
-            >>> x = Err("not a 2")
-            >>> y = Err("late error")
-            >>> x.and_(y)
-            Err('not a 2')
+            x = Ok(2)
+            y = Err("late error")
+            assert x.and_(y).unwrap_err() == "late error"
 
-            >>> x = Ok(2)
-            >>> y = Ok("different result type")
-            >>> x.and_(y)
-            Ok('different result type')
+            x = Err("early error")
+            y = Ok("foo")
+            assert x.and_(y).unwrap_err() == "early error"
 
+            x = Err("not a 2")
+            y = Err("late error")
+            assert x.and_(y).unwrap_err() == "not a 2"
+
+            x = Ok(2)
+            y = Ok("different result type")
+            assert x.and_(y).unwrap() == "different result type"
             ```
         """
 
@@ -688,14 +661,13 @@ class ResultType[T, E](Pipe, Protocol):
 
         Example:
             ```python
-            >>> from pyochain import Ok, Err, Result
-            >>> def to_str(x: int) -> Result[str, str]:
-            ...     return Ok(str(x))
-            >>> Ok(2).and_then(to_str)
-            Ok('2')
-            >>> Err("error").and_then(to_str)
-            Err('error')
+            from pyochain import Ok, Err, Result
 
+            def to_str(x: int) -> Result[str, str]:
+                return Ok(str(x))
+
+            assert Ok(2).and_then(to_str).unwrap() == "2"
+            assert Err("error").and_then(to_str), unwrap_err() == "error"
             ```
         """
 
@@ -719,14 +691,13 @@ class ResultType[T, E](Pipe, Protocol):
 
         Example:
             ```python
-            >>> from pyochain import Ok, Err, Result
-            >>> def fallback(e: str) -> Result[int, str]:
-            ...     return Ok(len(e))
-            >>> Ok(2).or_else(fallback)
-            Ok(2)
-            >>> Err("foo").or_else(fallback)
-            Ok(3)
+            from pyochain import Ok, Err, Result
 
+            def fallback(e: str) -> Result[int, str]:
+                return Ok(len(e))
+
+            assert Ok(2).or_else(fallback).unwrap() == 2
+            assert Err("foo").or_else(fallback).unwrap() == 3
             ```
         """
 
@@ -739,14 +710,12 @@ class ResultType[T, E](Pipe, Protocol):
             Option[T]: An `Option` containing the `Ok` value, or `None` if the result is `Err`.
 
         Example:
-            ```python
-            >>> from pyochain import Ok, Err
-            >>> Ok(2).ok()
-            Some(2)
-            >>> Err("error").ok()
-            NONE
+                ```python
+                from pyochain import Ok, Err, NONE, Some
 
-            ```
+                assert Ok(2).ok().unwrap() == 2
+                assert Err("error").ok() == NONE
+                ```
         """
 
     def err(self) -> Option[E]:
@@ -759,12 +728,10 @@ class ResultType[T, E](Pipe, Protocol):
 
         Example:
             ```python
-            >>> from pyochain import Ok, Err
-            >>> Ok(2).err()
-            NONE
-            >>> Err("error").err()
-            Some('error')
+            from pyochain import Ok, Err, NONE, Some
 
+            assert Ok(2).err() == NONE
+            assert Err("error").err().unwrap() == "error"
             ```
         """
 
@@ -783,14 +750,11 @@ class ResultType[T, E](Pipe, Protocol):
 
         Example:
             ```python
-            >>> from pyochain import Ok, Err
-            >>> Ok(2).is_ok_and(lambda x: x > 1)
-            True
-            >>> Ok(0).is_ok_and(lambda x: x > 1)
-            False
-            >>> Err("err").is_ok_and(lambda x: x > 1)
-            False
+            from pyochain import Ok, Err
 
+            assert Ok(2).is_ok_and(lambda x: x > 1) == True
+            assert Ok(0).is_ok_and(lambda x: x > 1) == False
+            assert Err("err").is_ok_and(lambda x: x > 1) == False
             ```
         """
 
@@ -809,14 +773,11 @@ class ResultType[T, E](Pipe, Protocol):
 
         Example:
             ```python
-            >>> from pyochain import Err, Ok
-            >>> Err("foo").is_err_and(lambda e: len(e) == 3)
-            True
-            >>> Err("bar").is_err_and(lambda e: e == "baz")
-            False
-            >>> Ok(2).is_err_and(lambda e: True)
-            False
+            from pyochain import Err, Ok
 
+            assert Err("foo").is_err_and(lambda e: len(e) == 3) == True
+            assert Err("bar").is_err_and(lambda e: e == "baz") == False
+            assert Ok(2).is_err_and(lambda e: True) == False
             ```
         """
 
@@ -840,12 +801,10 @@ class ResultType[T, E](Pipe, Protocol):
 
         Example:
             ```python
-            >>> from pyochain import Ok, Err
-            >>> Ok(2).map_or(10, lambda x: x * 2)
-            4
-            >>> Err("err").map_or(10, lambda x: x * 2)
-            10
+            from pyochain import Ok, Err
 
+            assert Ok(2).map_or(10, lambda x: x * 2) == 4
+            assert Err("err").map_or(10, lambda x: x * 2) == 10
             ```
         """
 
@@ -865,14 +824,11 @@ class ResultType[T, E](Pipe, Protocol):
 
         Example:
             ```python
-            >>> from pyochain import Ok, Err, Some, NONE
-            >>> Ok(Some(2)).transpose()
-            Some(Ok(2))
-            >>> Ok(NONE).transpose()
-            NONE
-            >>> Err("err").transpose()
-            Some(Err('err'))
+            from pyochain import Ok, Err, Some, NONE
 
+            assert Ok(Some(2)).transpose().unwrap().unwrap() == 2
+            assert Ok(NONE).transpose() == NONE
+            assert Err("err").transpose().unwrap().unwrap_err() == "err"
             ```
         """
 
@@ -887,16 +843,12 @@ class ResultType[T, E](Pipe, Protocol):
 
         Example:
             ```python
-            >>> from pyochain import Ok, Err
-            >>> Ok(2).or_(Err("late error"))
-            Ok(2)
-            >>> Err("early error").or_(Ok(2))
-            Ok(2)
-            >>> Err("not a 2").or_(Err("late error"))
-            Err('late error')
-            >>> Ok(2).or_(Ok(100))
-            Ok(2)
+            from pyochain import Ok, Err
 
+            assert Ok(2).or_(Err("late error")).unwrap() == 2
+            assert Err("early error").or_(Ok(2)).unwrap() == 2
+            assert Err("not a 2").or_(Err("late error")).unwrap_err() == "late error"
+            assert Ok(2).or_(Ok(100)).unwrap() == 2
             ```
         """
 

--- a/pyochain/core/_result.pyi
+++ b/pyochain/core/_result.pyi
@@ -16,10 +16,10 @@ def then_if_true[T](value: T, *, predicate: Callable[[T], bool]) -> Option[T]:
 
     Example:
         ```python
-        from pyochain import then_if_true, Some, NONE
+        from pyochain import then_if_true, Some
 
         assert then_if_true(42, predicate=lambda x: x == 42) == Some(42)
-        assert then_if_true(21, predicate=lambda x: x == 42) == NONE
+        assert then_if_true(21, predicate=lambda x: x == 42).is_none()
 
         from pathlib import Path
 
@@ -39,13 +39,13 @@ def then_if_some[T](value: T) -> Option[T]:
 
     Example:
         ```python
-        from pyochain import then_if_some, Some, NONE
+        from pyochain import then_if_some, Some
 
         assert then_if_some(42) == Some(42)
-        assert then_if_some(0) == NONE
+        assert then_if_some(0).is_none()
         assert then_if_some("hello") == Some("hello")
-        assert then_if_some("") == NONE
-        assert then_if_some(()) == NONE  # Empty sequence is falsy
+        assert then_if_some("").is_none()
+        assert then_if_some(()).is_none()  # Empty sequence is falsy
         ```
     """
 
@@ -101,14 +101,11 @@ class ResultType[T, E](Pipe, Protocol):
                 case Err(error):
                     return f"Failure: {error}"
 
-        assert (
-            is_positive(5).map(lambda s: s.upper()).pipe(handle_variant)
-            == "Success: VALUE IS 5"
-        )
-        assert (
-            is_positive(-3).map(lambda s: s.upper()).pipe(handle_variant)
-            == "Failure: -3 is not positive"
-        )
+        res1 = is_positive(5).map(lambda s: s.upper()).pipe(handle_variant)
+        assert res1 == "Success: VALUE IS 5"
+
+        res2 = is_positive(-3).map(lambda s: s.upper()).pipe(handle_variant)
+        assert res2 == "Failure: -3 is not positive"
         ```
     """
 
@@ -158,10 +155,10 @@ class ResultType[T, E](Pipe, Protocol):
 
         Example:
             ```python
-            from pyochain import Ok, Err, Some, NONE
+            from pyochain import Ok, Err, Some
 
             assert Ok(7).iter().next() == Some(7)
-            assert Err("nothing!").iter().next() == NONE
+            assert Err("nothing!").iter().next().is_none()
             ```
         """
 
@@ -324,10 +321,10 @@ class ResultType[T, E](Pipe, Protocol):
             from pyochain import Ok, Err, Result
 
             x: Result[int, str] = Ok(2)
-            assert x.is_ok() == True
+            assert x.is_ok()
 
             y: Result[int, str] = Err("Some error message")
-            assert y.is_ok() == False
+            assert not y.is_ok()
             ```
         """
 
@@ -342,10 +339,10 @@ class ResultType[T, E](Pipe, Protocol):
             from pyochain import Ok, Err, Result
 
             x: Result[int, str] = Ok(2)
-            assert x.is_err() == False
+            assert not x.is_err()
 
             y: Result[int, str] = Err("Some error message")
-            assert y.is_err() == True
+            assert y.is_err()
             ```
         """
 
@@ -601,9 +598,8 @@ class ResultType[T, E](Pipe, Protocol):
             from pyochain import Err, Vec
 
             seen = Vec[str](())
-            assert (
-                Err("oops").inspect_err(lambda e: seen.append(e)).unwrap_err() == "oops"
-            )
+            res = Err("oops").inspect_err(lambda e: seen.append(e)).unwrap_err()
+            assert res == "oops"
             assert seen == Vec(["oops"])
             ```
         """
@@ -711,10 +707,10 @@ class ResultType[T, E](Pipe, Protocol):
 
         Example:
                 ```python
-                from pyochain import Ok, Err, NONE, Some
+                from pyochain import Ok, Err, Some
 
                 assert Ok(2).ok().unwrap() == 2
-                assert Err("error").ok() == NONE
+                assert Err("error").ok().is_none()
                 ```
         """
 
@@ -728,9 +724,9 @@ class ResultType[T, E](Pipe, Protocol):
 
         Example:
             ```python
-            from pyochain import Ok, Err, NONE, Some
+            from pyochain import Ok, Err, Some
 
-            assert Ok(2).err() == NONE
+            assert Ok(2).err().is_none()
             assert Err("error").err().unwrap() == "error"
             ```
         """
@@ -752,9 +748,9 @@ class ResultType[T, E](Pipe, Protocol):
             ```python
             from pyochain import Ok, Err
 
-            assert Ok(2).is_ok_and(lambda x: x > 1) == True
-            assert Ok(0).is_ok_and(lambda x: x > 1) == False
-            assert Err("err").is_ok_and(lambda x: x > 1) == False
+            assert Ok(2).is_ok_and(lambda x: x > 1)
+            assert not Ok(0).is_ok_and(lambda x: x > 1)
+            assert not Err("err").is_ok_and(lambda x: x > 1)
             ```
         """
 
@@ -775,9 +771,9 @@ class ResultType[T, E](Pipe, Protocol):
             ```python
             from pyochain import Err, Ok
 
-            assert Err("foo").is_err_and(lambda e: len(e) == 3) == True
-            assert Err("bar").is_err_and(lambda e: e == "baz") == False
-            assert Ok(2).is_err_and(lambda e: True) == False
+            assert Err("foo").is_err_and(lambda e: len(e) == 3)
+            assert not Err("bar").is_err_and(lambda e: e == "baz")
+            assert not Ok(2).is_err_and(lambda e: True)
             ```
         """
 
@@ -827,7 +823,7 @@ class ResultType[T, E](Pipe, Protocol):
             from pyochain import Ok, Err, Some, NONE
 
             assert Ok(Some(2)).transpose().unwrap().unwrap() == 2
-            assert Ok(NONE).transpose() == NONE
+            assert Ok(NONE).transpose().is_none()
             assert Err("err").transpose().unwrap().unwrap_err() == "err"
             ```
         """

--- a/pyochain/core/_sliceview.pyi
+++ b/pyochain/core/_sliceview.pyi
@@ -26,16 +26,14 @@ class SliceView[T](PyoSequence[T]):
 
     Examples:
         ```python
-        >>> from pyochain import SliceView, Seq
-        >>> sv = SliceView([0, 1, 2, 3, 4, 5])
-        >>> sv[1:4].iter().collect(Seq)
-        Seq(1, 2, 3)
-        >>> sv[::2].iter().collect(Seq)
-        Seq(0, 2, 4)
-        >>> sv2 = sv[1:][::2]  # composed — O(1), no copy
-        >>> sv2.iter().collect(Seq)
-        Seq(1, 3, 5)
+        from pyochain import SliceView, Seq
 
+        sv = SliceView([0, 1, 2, 3, 4, 5])
+        assert sv[1:4].iter().collect(Seq) == Seq([1, 2, 3])
+        assert sv[::2].iter().collect(Seq) == Seq([0, 2, 4])
+
+        sv2 = sv[1:][::2]  # composed — O(1), no copy
+        assert sv2.iter().collect(Seq) == Seq([1, 3, 5])
         ```
     """
 
@@ -108,15 +106,13 @@ class SliceView[T](PyoSequence[T]):
             This can be useful for sliding windows:
 
             ```python
-            >>> from pyochain import SliceView, Range, Seq
-            >>> data = Range(0, 10).iter().collect(Seq)
-            >>> sv = SliceView(data, 0, 3)
-            >>> sv.iter().collect(Seq)
-            Seq(0, 1, 2)
-            >>> sv.advance(3)
-            SliceView(Seq(0, 1, 2, 3, 4, 5, 6, 7, 8, 9))[3:6:1]
-            >>> sv.iter().collect(Seq)
-            Seq(3, 4, 5)
+            from pyochain import SliceView, Range, Seq
 
+            data = Range(0, 10).iter().collect(Seq)
+            sv = SliceView(data, 0, 3)
+            assert sv.iter().collect(Seq) == Seq([0, 1, 2])
+
+            sv.advance(3)
+            assert sv.iter().collect(Seq) == Seq([3, 4, 5])
             ```
         """


### PR DESCRIPTION
### What's Changed

- Migrated legacy `>>>` doctests to markdown code blocks with `assert` statements across `.pyi` stub files.
- Included missing imports in certain code blocks so each markdown test is self-contained.
- Used `.unwrap()`/`.unwrap_err()` in certain statements to cleanly handle values and prevent type/unwrap assertion issues during test conversion.

### Checklist

- [x] Ran `uv run ruff check .` (All checks passed)
- [x] Ran `uv run ruff format . --preview` 
- [x] Ran `uv run ruff check . --fix --unsafe-fixes` (All checks passed)
- [x] Ran `uv run pytest` (1413 passed, 426 skipped) 

Closes #82 