### PR TITLE
fix(docs): add returns_named_value property to handle description leaks

### DIFF
--- a/zensical.toml
+++ b/zensical.toml
@@ -112,6 +112,9 @@ show_overloads = true
 show_source = true
 signature_crossrefs = true
 
+[project.plugins.mkdocstrings.handlers.python.options.docstring_options]
+returns_named_value = false
+
 
 [project.markdown_extensions.pymdownx.superfences]
 custom_fences = [


### PR DESCRIPTION
### What's Changed

- Fixed description leaks in return types involving generics.
- Converts the **Returns** table format to a 2-column layout (`Type | Description`).

### Checklist

Tested the build and verified the site locally.
- [x] `uv run zensical build -c`
- [x] `uv run zensical serve` 

Fixes #9 